### PR TITLE
No site should be enabled by default.

### DIFF
--- a/setup.conf
+++ b/setup.conf
@@ -66,7 +66,7 @@ bibliotik= 0
 bitgamer= 0
 bitme= 0
 bitmetv= 0
-broadcasthenet= 1
+broadcasthenet= 0
 brokenstones= 0
 delish= 0
 digitalhive= 0
@@ -87,7 +87,7 @@ scenehd= 0
 sciencehd= 0
 sharetheremote= 0
 shellife=0
-stopthepresses=1
+stopthepresses=0
 tehconnection= 0
 thebox= 0
 theempire= 0
@@ -100,7 +100,7 @@ torrentleech= 0
 torrentvault= 0
 undergroundgamer= 0
 waffles= 0
-whatcd= 1
+whatcd= 0
 x264= 0
 
 [aliases]


### PR DESCRIPTION
Prevents accidents from happening.
