### PR TITLE
Credentials.conf header fix

### DIFF
--- a/credentials.conf
+++ b/credentials.conf
@@ -1,6 +1,6 @@
 ;WHATauto credentials.conf
 
-;nickowner= the ident (i.e. abc@user.class.what.cd, or 123@user.*what.cd to match all userclasses)
+;nickowner= the ident (i.e. 123@username.class.what.cd, or 123@username.*.what.cd to match all userclasses)
 ;username= your site username
 ;password= your site password
 ;botNick= the nick you want your bot to use


### PR DESCRIPTION
Clarified nick owner header (switched 'user' to 'username' to avoid confusion with user as a class) and fixed missing period in suggested string to match all user classes.
