### PR TITLE
Updated BTN regex

### DIFF
--- a/regex.conf
+++ b/regex.conf
@@ -261,7 +261,7 @@ announcechannel: #btn-whatauto
 announcelines: 1
 announces: video
 downloadType: 1
-video: ([^\|]*) \| (?:AutoFillFail|S(?:eason )?(\d+)(?:E(\d+))?|[^\|]*) \| (Episode|Season) \| (\d+) \| (AVI|MKV|VOB|MPEG|MP4|ISO|WMV|TS|M4V|M2TS|---) \| (XViD|x264|x264-Hi10P|MPEG2|DiVX|DVDR|VC-1|h.264|WMV|BD|---) \| (HDTV|PDTV|DSR|DVDRip|TVRip|VHSRip|Bluray|BDRip|BRRip|DVD5|DVD9|HDDVD|WEBRip|WEB-DL|BD5|BD9|BD25|BD50|Mixed|Unknown|---) \| (SD|720p|1080p|1080i|Portable Device|---) \| (Yes|No) \| (Yes|No) \| (\d+) \| ([^\|]*) \| ([^\|]*) (?:\| (.*))?
+video: ([^\|]*) \| (?:AutoFillFail|S(?:eason )?(\d+)(?:E(\d+))?|[^\|]*) \| (Episode|Season) \| (\d+) \| (AVI|MKV|VOB|MPEG|MP4|ISO|WMV|TS|M4V|M2TS|---) \| (XViD|x264-Hi10P|MPEG2|DiVX|DVDR|VC-1|x264|H.264|H.265|WMV|BD|---) \| (HDTV|PDTV|DSR|DVDRip|TVRip|VHSRip|Bluray|BDRip|BRRip|DVD5|DVD9|HDDVD|WEBRip|WEB-DL|BD5|BD9|BD25|BD50|Mixed|Unknown|---) \| (SD|720p|1080p|1080i|2160p|Portable Device|---) \| (Yes|No) \| (Yes|No) \| (\d+) \| ([^\|]*) \| ([^\|]*) (?:\| (.*))?
 loginURL: https://broadcasthe.net/login.php
 morepostdata: 'keeplogged' : '1'
 downloadURL: https://broadcasthe.net/torrents.php?action=download&id=


### PR DESCRIPTION
BTN made changes to their announce formats. h.264 is now H.264. Also asked to include 2160p and H.265.