### PR TITLE
Add support for HTTPS webserver

### DIFF
--- a/reports.conf
+++ b/reports.conf
@@ -22,6 +22,10 @@ downloaded = 0
 seen = 0
 downloaded = 0
 
+[bithdtv]
+seen = 0
+downloaded = 0
+
 [bitme]
 seen = 0
 downloaded = 0
@@ -114,6 +118,10 @@ downloaded = 0
 seen = 0
 downloaded = 0
 
+[stopthepresses]
+seen = 0
+downloaded = 0
+
 [tehconnection]
 seen = 0
 downloaded = 0
@@ -131,6 +139,14 @@ seen = 0
 downloaded = 0
 
 [theplace]
+seen = 0
+downloaded = 0
+
+[theswarm]
+seen = 0
+downloaded = 0
+
+[tophos]
 seen = 0
 downloaded = 0
 

--- a/setup.conf
+++ b/setup.conf
@@ -45,6 +45,10 @@ password=
 port=
 ;WEBUI IP (only required if you want to bind the server to a specific ip)
 webserverip=
+webserverssl=0
+; full path to server certfile
+; openssl req -new -x509 -keyout /home/pywhatauto/server.pem -out /home/pywhatauto/server.pem -days 365 -nodes
+certfile=/home/pywhatauto/server.pem
 
 [notification]
 gmail= j5@gmail.com


### PR DESCRIPTION
Added simple support for HTTPS to built in web-server.

Dev certificate could be created by:
```
openssl req -new -x509 -keyout server.pem -out server.pem -days 365 -nodes
```