### PR TITLE
Removed whatcd configuration example

### DIFF
--- a/credentials.conf.example
+++ b/credentials.conf.example
@@ -413,16 +413,6 @@ nickservpass=
 username=
 password=
 
-[whatcd]
-nickowner=
-chanfilter=#whatbot
-username=
-password=
-botnick=
-irckey=
-nickservpass=
-;watch=
-
 [x264]
 nickowner=
 username=


### PR DESCRIPTION
Whatcd configuration is obsolete as the tracker no longer exists.